### PR TITLE
download of xls & fix restart problem of container

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -133,6 +133,9 @@ wait_for_php_fpm
 # MySQL          #
 ##################
 
+# force set to be +e so error do NEVER terminate the script and errorhandling can be done here
+set +e
+
 # Check if password was changed
 echo "\
 [client]

--- a/nginx/akaunting
+++ b/nginx/akaunting
@@ -6,7 +6,7 @@ server {
     root /var/www/akaunting/root;
 
     # Static files
-    location ~ ^/(public|modules|vendor)/(.*\.(ico|gif|jpg|jpeg|png|js|css|less|sass|font|woff|woff2|eot|ttf|svg))$ {
+    location ~ ^/(public|modules|vendor)/(.*\.(ico|gif|jpg|jpeg|png|js|css|less|sass|font|woff|woff2|eot|ttf|svg|csv|xls|xlsx))$ {
         alias /var/www/akaunting/$1/$2;
     }
 


### PR DESCRIPTION
To import data into invoices issues etc a certain format needs to befollowed, akkaunting provides examples in the form of .xlsx and .csv file under the public directory. Unfortunately they are blocked
- - - 
after a restart of the container i would face lockout of the container
akaunting_1  | Waiting for php-fpm
akaunting_1  | == MYSQL_DEFAULT_PASSWORD
akaunting_1  | ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)


set -e seemed to be active in my setup, causing the script to terminate early
termination was not desired as after a restart failing access to mysql the entrypointscript was
supposed to continue based on the error status.